### PR TITLE
fix: docker config and missing uvicorn dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,9 @@ backend/.coverage
 # System files
 .DS_Store
 
+# Environment variables
+.env
+backend/.env
+
 # Database files
 backend/app/data/*.csv

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.135.1
+uvicorn==0.34.3
 pydantic==2.12.5
 pydantic_core==2.41.5
 annotated-types==0.7.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./backend/app/data:/app/data
+      - ./backend/app/data:/app/app/data
     environment:
       - ENVIRONMENT=development
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add `uvicorn` to `requirements.txt` — was missing, caused container to fail on startup with `executable file not found in $PATH`
- Fix volume mount path in `docker-compose.yml` from `/app/data` to `/app/app/data` — Dockerfile `COPY . .` puts app code at `/app/app/`, so data files land at `/app/app/data/`
- Add `.env` and `backend/.env` to `.gitignore`