### PR TITLE
Adjusting the Pytest With Real Dataset and Refactoring Code

### DIFF
--- a/backend/app/exception_handlers.py
+++ b/backend/app/exception_handlers.py
@@ -1,0 +1,13 @@
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+
+async def request_validation_exception_handler(request, exc: RequestValidationError):
+    del request
+    return JSONResponse(
+        status_code=422,
+        content={
+            "message": "Invalid request parameters.",
+            "details": exc.errors(),
+        },
+    )

--- a/backend/tests/test_invalid_query_handling.py
+++ b/backend/tests/test_invalid_query_handling.py
@@ -1,124 +1,117 @@
-from app.routers import search_router
-from app.schemas.search_filters import CurrentUser, Role
+import pytest
+import uuid
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
+from app.dependencies import get_current_user_full
+from app.exception_handlers import request_validation_exception_handler
+from app.main import app as main_app
+from app.routers import search_router
+from app.schemas.user import UserInDB
 
-def fake_admin_user():
-    return CurrentUser(
-        user_id="admin1",
-        role=Role.ADMIN,
-        owner_restaurant_ids=[],
-    )
+ADMIN_ID = uuid.uuid4()
+MOCK_ADMIN = UserInDB(
+    id=ADMIN_ID,
+    email="admin@example.com",
+    role="admin",
+    password_hash="hashed",
+)
 
+FAKE_ROWS = [
+    {
+        "restaurant_id": "R1",
+        "restaurant_name": "Sushi House",
+        "city": "Kelowna",
+        "cuisine": "Japanese",
+        "customer_id": "C1",
+        "order_id": "O1",
+        "order_status": "Delivered",
+        "order_value": "25.50",
+        "item_name": "Salmon Roll",
+        "category": "Sushi",
+        "price": "12.50",
+    },
+    {
+        "restaurant_id": "R2",
+        "restaurant_name": "Burger Town",
+        "city": "Vancouver",
+        "cuisine": "Fast Food",
+        "customer_id": "C2",
+        "order_id": "O2",
+        "order_status": "Placed",
+        "order_value": "15.00",
+        "item_name": "Cheeseburger",
+        "category": "Burger",
+        "price": "9.99",
+    },
+]
 
-def fake_load_rows():
-    return [
-        {
-            "restaurant_id": "R1",
-            "restaurant_name": "Sushi House",
-            "city": "Kelowna",
-            "cuisine": "Japanese",
-            "customer_id": "C1",
-            "order_id": "O1",
-            "order_status": "Delivered",
-            "order_value": "25.50",
-            "item_name": "Salmon Roll",
-            "category": "Sushi",
-            "price": "12.50",
-        },
-        {
-            "restaurant_id": "R2",
-            "restaurant_name": "Burger Town",
-            "city": "Vancouver",
-            "cuisine": "Fast Food",
-            "customer_id": "C2",
-            "order_id": "O2",
-            "order_status": "Placed",
-            "order_value": "15.00",
-            "item_name": "Cheeseburger",
-            "category": "Burger",
-            "price": "9.99",
-        },
-    ]
+# Separate app needed to register the custom RequestValidationError handler, 
+# since the main app uses the default FastAPI handler which doesn't format the error response as expected by the tests
+validation_app = FastAPI()
+validation_app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+validation_app.include_router(search_router.router)
+validation_app.dependency_overrides[search_router.get_search_user] = lambda: None
 
+validation_client = TestClient(validation_app, raise_server_exceptions=False)
 
-# This is to create a small test app just for search-related tests
-app = FastAPI()
-
-
-@app.exception_handler(RequestValidationError)
-async def request_validation_exception_handler(request, exc):
-    del request
-    return JSONResponse(
-        status_code=422,
-        content={
-            "message": "Invalid request parameters.",
-            "details": exc.errors(),
-        },
-    )
-
-
-app.include_router(search_router.router)
-
-# Create override dependency and mock repo data
-app.dependency_overrides[search_router.get_search_user] = fake_admin_user
-search_router.service.repo.load_all_rows = fake_load_rows
-
-client = TestClient(app)
+client = TestClient(main_app)
 
 
-def test_restaurants_unsupported_filter_returns_422():
+@pytest.fixture(autouse=True)
+def override_auth():
+    main_app.dependency_overrides[get_current_user_full] = lambda: MOCK_ADMIN
+    yield
+    main_app.dependency_overrides.clear()
+
+
+def test_restaurants_unsupported_filter_returns_422(mocker):
+    mocker.patch.object(search_router.service.repo, "load_all_rows", return_value=FAKE_ROWS)
     response = client.get("/search/restaurants?bad_filter=test")
 
     assert response.status_code == 422
     body = response.json()
-
     assert "detail" in body
     assert body["detail"]["message"] == "Unsupported query parameter(s)."
     assert "bad_filter" in body["detail"]["unsupported"]
 
 
-def test_menu_items_invalid_price_range_returns_422():
+def test_menu_items_invalid_price_range_returns_422(mocker):
+    mocker.patch.object(search_router.service.repo, "load_all_rows", return_value=FAKE_ROWS)
     response = client.get("/search/menu-items?min_price=100&max_price=10")
 
     assert response.status_code == 422
     body = response.json()
-
     assert body["detail"]["message"] == "Invalid price range."
     assert body["detail"]["reason"] == "min_price cannot be greater than max_price."
 
 
-def test_orders_invalid_order_value_range_returns_422():
+def test_orders_invalid_order_value_range_returns_422(mocker):
+    mocker.patch.object(search_router.service.repo, "load_all_rows", return_value=FAKE_ROWS)
     response = client.get("/search/orders?min_order_value=80&max_order_value=10")
 
     assert response.status_code == 422
     body = response.json()
-
     assert body["detail"]["message"] == "Invalid order value range."
-    assert (
-        body["detail"]["reason"]
-        == "min_order_value cannot be greater than max_order_value."
-    )
+    assert body["detail"]["reason"] == "min_order_value cannot be greater than max_order_value."
 
 
 def test_invalid_query_type_returns_422():
-    response = client.get("/search/restaurants?page=abc")
+    # Uses the custom validation app so the RequestValidationError is formatted correctly
+    response = validation_client.get("/search/restaurants?page=abc")
 
     assert response.status_code == 422
     body = response.json()
-
     assert body["message"] == "Invalid request parameters."
     assert "details" in body
 
 
-def test_error_response_does_not_expose_internal_details():
+def test_error_response_does_not_expose_internal_details(mocker):
+    mocker.patch.object(search_router.service.repo, "load_all_rows", return_value=FAKE_ROWS)
     response = client.get("/search/restaurants?bad_filter=test")
 
     assert response.status_code == 422
     body = response.json()
-
     assert "traceback" not in str(body).lower()
     assert "exception" not in str(body).lower()

--- a/backend/tests/test_pricing_router.py
+++ b/backend/tests/test_pricing_router.py
@@ -82,21 +82,18 @@ def override_auth_as_customer():
 # ------------------------------------------------------------------ #
 
 def test_get_price_breakdown_route_returns_200(mocker):
-    """The endpoint should return HTTP 200 for a valid order."""
     mocker.patch("app.routers.pricing_router.pricing_service.get_price_breakdown", return_value=MOCK_BREAKDOWN)
     response = client.get(f"/pricing/orders/{ORDER_ID}/breakdown")
     assert response.status_code == 200
 
 
 def test_get_price_breakdown_route_order_id_in_response(mocker):
-    """The response body should include the correct order_id."""
     mocker.patch("app.routers.pricing_router.pricing_service.get_price_breakdown", return_value=MOCK_BREAKDOWN)
     body = client.get(f"/pricing/orders/{ORDER_ID}/breakdown").json()
     assert body["order_id"] == str(ORDER_ID)
 
 
 def test_get_price_breakdown_route_food_price(mocker):
-    """The response should include the food_price from Kaggle lookup."""
     mocker.patch("app.routers.pricing_router.pricing_service.get_price_breakdown", return_value=MOCK_BREAKDOWN)
     body = client.get(f"/pricing/orders/{ORDER_ID}/breakdown").json()
     assert body["food_price"] == 15.00
@@ -117,7 +114,7 @@ def test_get_price_breakdown_route_delivery_fee_breakdown(mocker):
 
 
 def test_get_price_breakdown_route_totals(mocker):
-    """The subtotal, tax, and total should be correct."""
+    """The subtotal, tax, and total should be correct as indicate below."""
     mocker.patch("app.routers.pricing_router.pricing_service.get_price_breakdown", return_value=MOCK_BREAKDOWN)
     body = client.get(f"/pricing/orders/{ORDER_ID}/breakdown").json()
     assert body["subtotal"] == 22.00
@@ -126,7 +123,6 @@ def test_get_price_breakdown_route_totals(mocker):
 
 
 def test_get_price_breakdown_route_returns_404_for_missing_order(mocker):
-    """A non-existent order_id should return 404."""
     mocker.patch(
         "app.routers.pricing_router.pricing_service.get_price_breakdown",
         side_effect=HTTPException(status_code=404, detail="Order not found"),
@@ -137,7 +133,7 @@ def test_get_price_breakdown_route_returns_404_for_missing_order(mocker):
 
 
 def test_get_price_breakdown_route_returns_403_for_wrong_customer(mocker):
-    """A customer who did not place the order should get 403."""
+    """A customer who did not place the order should get a code 403."""
     mocker.patch(
         "app.routers.pricing_router.pricing_service.get_price_breakdown",
         side_effect=HTTPException(status_code=403, detail="You do not have permission to view this order breakdown"),
@@ -171,7 +167,6 @@ def test_analytics_route_returns_correct_fields(mocker):
 
 
 def test_analytics_route_returns_correct_values(mocker):
-    """The analytics response values should match what the service returns."""
     app.dependency_overrides[get_current_user] = lambda: MOCK_ADMIN
     mocker.patch("app.routers.pricing_router.pricing_service.get_pricing_analytics", return_value=MOCK_ANALYTICS)
     body = client.get("/pricing/analytics").json()
@@ -181,7 +176,6 @@ def test_analytics_route_returns_correct_values(mocker):
 
 
 def test_analytics_route_customer_returns_403(mocker):
-    """Non-admin users should be denied access to analytics."""
     mocker.patch(
         "app.routers.pricing_router.pricing_service.get_pricing_analytics",
         side_effect=HTTPException(status_code=403, detail="Only admins can view pricing analytics"),

--- a/backend/tests/test_pricing_service.py
+++ b/backend/tests/test_pricing_service.py
@@ -1,9 +1,6 @@
-from types import SimpleNamespace
-from unittest.mock import patch
-from uuid import uuid4
-
 import pytest
 from fastapi import HTTPException
+from uuid import uuid4
 
 from app.schemas.order import (
     DeliveryMethod,
@@ -12,6 +9,7 @@ from app.schemas.order import (
     TrafficCondition,
     WeatherCondition,
 )
+from app.schemas.user import UserInDB
 from app.services.pricing_service import PricingService
 
 
@@ -39,6 +37,11 @@ class FakeKaggleOrderRepository:
 # Shared fixtures
 # ------------------------------------------------------------------ #
 
+CUSTOMER_ID = uuid4()
+ADMIN_ID = uuid4()
+OTHER_ID = uuid4()
+
+
 @pytest.fixture
 def sample_order():
     """
@@ -51,7 +54,7 @@ def sample_order():
     """
     return Order(
         order_id=uuid4(),
-        customer_id="customer-1",
+        customer_id=str(CUSTOMER_ID),
         restaurant_id=101,
         food_item="Burger",
         order_time="2026-03-16T12:00:00Z",
@@ -66,24 +69,24 @@ def sample_order():
 
 @pytest.fixture
 def customer_user():
-    return SimpleNamespace(id="customer-1", role="customer")
+    return UserInDB(id=CUSTOMER_ID, email="customer@example.com", role="customer", password_hash="hashed")
 
 
 @pytest.fixture
 def other_customer():
-    return SimpleNamespace(id="someone-else", role="customer")
+    return UserInDB(id=OTHER_ID, email="other@example.com", role="customer", password_hash="hashed")
 
 
 @pytest.fixture
 def admin_user():
-    return SimpleNamespace(id="admin-1", role="admin")
+    return UserInDB(id=ADMIN_ID, email="admin@example.com", role="admin", password_hash="hashed")
 
 
 # ------------------------------------------------------------------ #
 # Test: successful price breakdown — verify every number
 # ------------------------------------------------------------------ #
 
-def test_get_price_breakdown_success(sample_order, customer_user):
+def test_get_price_breakdown_success(mocker, sample_order, customer_user):
     """
     With get_median_price mocked to return $15.00 we can verify
     every calculated number exactly.
@@ -101,13 +104,13 @@ def test_get_price_breakdown_success(sample_order, customer_user):
       tax                 = $1.10  (22.00 * 5%)
       total               = $23.10 (22.00 + 1.10)
     """
+    mocker.patch("app.services.pricing_service.get_median_price", return_value=15.00)
     service = PricingService(
         order_repo=FakeOrderRepository(order=sample_order),
         kaggle_repo=FakeKaggleOrderRepository(order=None),
     )
 
-    with patch("app.services.pricing_service.get_median_price", return_value=15.00):
-        result = service.get_price_breakdown(str(sample_order.order_id), customer_user)
+    result = service.get_price_breakdown(str(sample_order.order_id), customer_user)
 
     assert result.order_id == str(sample_order.order_id)
     assert result.food_price == 15.00
@@ -131,15 +134,15 @@ def test_get_price_breakdown_success(sample_order, customer_user):
 # Test: access control
 # ------------------------------------------------------------------ #
 
-def test_get_price_breakdown_admin_can_view_any_order(sample_order, admin_user):
+def test_get_price_breakdown_admin_can_view_any_order(mocker, sample_order, admin_user):
     """Admin should be able to see any order's breakdown."""
+    mocker.patch("app.services.pricing_service.get_median_price", return_value=15.00)
     service = PricingService(
         order_repo=FakeOrderRepository(order=sample_order),
         kaggle_repo=FakeKaggleOrderRepository(order=None),
     )
 
-    with patch("app.services.pricing_service.get_median_price", return_value=15.00):
-        result = service.get_price_breakdown(str(sample_order.order_id), admin_user)
+    result = service.get_price_breakdown(str(sample_order.order_id), admin_user)
 
     assert result.order_id == str(sample_order.order_id)
 
@@ -232,7 +235,6 @@ def test_distance_fee_tier3_mid():
 def test_distance_fee_tier3_upper_boundary():
     """At exactly 15.0 km (max): $2.50 + (15.0 - 8.0) * 0.80 = $8.10"""
     service = PricingService()
-    # Use pytest.approx to handle floating point precision (e.g. 1.234500000000001)
     assert service._calculate_distance_fee(15.0) == pytest.approx(8.10)
 
 
@@ -285,22 +287,22 @@ def test_weather_surcharge_snowy():
 
 
 # ------------------------------------------------------------------ #
-# Test: pricing is deterministic — same inputs always give same output
+# Test: pricing is deterministic — same inputs always will give same output
 # ------------------------------------------------------------------ #
 
-def test_pricing_is_deterministic(sample_order, customer_user):
+def test_pricing_is_deterministic(mocker, sample_order, customer_user):
     """
     Calling get_price_breakdown twice with the same order must return
     the exact same numbers — no randomness allowed.
     """
+    mocker.patch("app.services.pricing_service.get_median_price", return_value=15.00)
     service = PricingService(
         order_repo=FakeOrderRepository(order=sample_order),
         kaggle_repo=FakeKaggleOrderRepository(order=None),
     )
 
-    with patch("app.services.pricing_service.get_median_price", return_value=15.00):
-        result1 = service.get_price_breakdown(str(sample_order.order_id), customer_user)
-        result2 = service.get_price_breakdown(str(sample_order.order_id), customer_user)
+    result1 = service.get_price_breakdown(str(sample_order.order_id), customer_user)
+    result2 = service.get_price_breakdown(str(sample_order.order_id), customer_user)
 
     assert result1.food_price == result2.food_price
     assert result1.delivery_fee.total_delivery_fee == result2.delivery_fee.total_delivery_fee
@@ -327,17 +329,17 @@ class FakeOrderRepoForAnalytics:
 
 @pytest.fixture
 def analytics_admin():
-    return SimpleNamespace(id="admin-1", role="admin")
+    return UserInDB(id=uuid4(), email="admin@example.com", role="admin", password_hash="hashed")
 
 
 @pytest.fixture
 def analytics_customer():
-    return SimpleNamespace(id="cust-1", role="customer")
+    return UserInDB(id=uuid4(), email="customer@example.com", role="customer", password_hash="hashed")
 
 
 @pytest.fixture
 def analytics_owner():
-    return SimpleNamespace(id="owner-1", role="owner", restaurant_id=101)
+    return UserInDB(id=uuid4(), email="owner@example.com", role="owner", password_hash="hashed", restaurant_id=101)
 
 
 @pytest.fixture
@@ -371,43 +373,43 @@ def two_orders():
     return [order_a, order_b]
 
 
-def test_analytics_admin_can_access(analytics_admin, two_orders):
+def test_analytics_admin_can_access(mocker, analytics_admin, two_orders):
+    mocker.patch("app.services.pricing_service.get_median_price", return_value=15.00)
     service = PricingService(
         order_repo=FakeOrderRepoForAnalytics(orders=two_orders),
         kaggle_repo=FakeKaggleOrderRepository(order=None),
     )
 
-    with patch("app.services.pricing_service.get_median_price", return_value=15.00):
-        result = service.get_pricing_analytics(analytics_admin)
+    result = service.get_pricing_analytics(analytics_admin)
 
     assert result is not None
 
 
-def test_analytics_total_orders(analytics_admin, two_orders):
+def test_analytics_total_orders(mocker, analytics_admin, two_orders):
+    mocker.patch("app.services.pricing_service.get_median_price", return_value=15.00)
     service = PricingService(
         order_repo=FakeOrderRepoForAnalytics(orders=two_orders),
         kaggle_repo=FakeKaggleOrderRepository(order=None),
     )
 
-    with patch("app.services.pricing_service.get_median_price", return_value=15.00):
-        result = service.get_pricing_analytics(analytics_admin)
+    result = service.get_pricing_analytics(analytics_admin)
 
     assert result.total_orders == 2
 
 
-def test_analytics_min_max_avg_order_value(analytics_admin, two_orders):
+def test_analytics_min_max_avg_order_value(mocker, analytics_admin, two_orders):
     """
     With get_median_price mocked to $15.00:
       order_a (Bike, 4km, Low, Sunny):  $15 + $4.50 delivery = $19.50, tax $0.98 -> total $20.48
       order_b (Car,  6km, High, Rainy): $15 + $10.50 delivery = $25.50, tax $1.28 -> total $26.78
     """
+    mocker.patch("app.services.pricing_service.get_median_price", return_value=15.00)
     service = PricingService(
         order_repo=FakeOrderRepoForAnalytics(orders=two_orders),
         kaggle_repo=FakeKaggleOrderRepository(order=None),
     )
 
-    with patch("app.services.pricing_service.get_median_price", return_value=15.00):
-        result = service.get_pricing_analytics(analytics_admin)
+    result = service.get_pricing_analytics(analytics_admin)
 
     assert result.min_order_value == 20.48
     assert result.max_order_value == 26.78
@@ -415,15 +417,15 @@ def test_analytics_min_max_avg_order_value(analytics_admin, two_orders):
     assert result.min_order_value < result.max_order_value
 
 
-def test_analytics_total_revenue_is_positive(analytics_admin, two_orders):
+def test_analytics_total_revenue_is_positive(mocker, analytics_admin, two_orders):
     """total_revenue = $20.48 + $26.78 = $47.26 (both orders use Kaggle price)"""
+    mocker.patch("app.services.pricing_service.get_median_price", return_value=15.00)
     service = PricingService(
         order_repo=FakeOrderRepoForAnalytics(orders=two_orders),
         kaggle_repo=FakeKaggleOrderRepository(order=None),
     )
 
-    with patch("app.services.pricing_service.get_median_price", return_value=15.00):
-        result = service.get_pricing_analytics(analytics_admin)
+    result = service.get_pricing_analytics(analytics_admin)
 
     assert result.total_revenue == 47.26
 

--- a/backend/tests/test_search_router.py
+++ b/backend/tests/test_search_router.py
@@ -1,102 +1,105 @@
-from app.routers import search_router
-from app.schemas.search_filters import CurrentUser, Role
-from fastapi import FastAPI
+import pytest
+import uuid
 from fastapi.testclient import TestClient
 
-app = FastAPI()
-app.include_router(search_router.router)
+from app.dependencies import get_current_user_full
+from app.main import app
+from app.routers import search_router
+from app.schemas.user import UserInDB
+
+ADMIN_ID = uuid.uuid4()
+MOCK_ADMIN = UserInDB(
+    id=ADMIN_ID,
+    email="admin@example.com",
+    role="admin",
+    password_hash="hashed",
+)
+
+FAKE_ROWS = [
+    {
+        "restaurant_id": "R1",
+        "restaurant_name": "Sushi House",
+        "city": "Kelowna",
+        "cuisine": "Japanese",
+        "customer_id": "C1",
+        "order_id": "O1",
+        "order_status": "Delivered",
+        "order_value": "25.50",
+    },
+    {
+        "restaurant_id": "R2",
+        "restaurant_name": "Burger Town",
+        "city": "Vancouver",
+        "cuisine": "Fast Food",
+        "customer_id": "C2",
+        "order_id": "O2",
+        "order_status": "Placed",
+        "order_value": "15.00",
+    },
+]
+
 client = TestClient(app)
 
 
-def fake_admin_user():
-    return CurrentUser(user_id="admin1", role=Role.ADMIN, owner_restaurant_ids=[])
-
-
-def fake_load_rows():
-    return [
-        {
-            "restaurant_id": "R1",
-            "restaurant_name": "Sushi House",
-            "city": "Kelowna",
-            "cuisine": "Japanese",
-            "customer_id": "C1",
-            "order_id": "O1",
-            "order_status": "Delivered",
-            "order_value": "25.50",
-        },
-        {
-            "restaurant_id": "R2",
-            "restaurant_name": "Burger Town",
-            "city": "Vancouver",
-            "cuisine": "Fast Food",
-            "customer_id": "C2",
-            "order_id": "O2",
-            "order_status": "Placed",
-            "order_value": "15.00",
-        },
-    ]
-
-
-def setup_module():
-    app.dependency_overrides[search_router.get_search_user] = fake_admin_user
-    search_router.service.repo.load_all_rows = fake_load_rows
-
-
-def teardown_module():
+@pytest.fixture(autouse=True)
+def override_auth():
+    app.dependency_overrides[get_current_user_full] = lambda: MOCK_ADMIN
+    yield
     app.dependency_overrides.clear()
 
 
-client = TestClient(app)
-
-
-def test_search_restaurants_success():
+def test_search_restaurants_success(mocker):
+    mocker.patch.object(search_router.service.repo, "load_all_rows", return_value=FAKE_ROWS)
     response = client.get("/search/restaurants?city=Kelowna")
 
     assert response.status_code == 200
     body = response.json()
-
     assert "meta" in body
     assert "data" in body
     assert body["meta"]["total"] == 1
     assert body["data"][0]["restaurant_name"] == "Sushi House"
 
 
-def test_search_restaurants_unsupported_filter():
+def test_search_restaurants_unsupported_filter(mocker):
+    mocker.patch.object(search_router.service.repo, "load_all_rows", return_value=FAKE_ROWS)
     response = client.get("/search/restaurants?invalid_filter=abc")
 
     assert response.status_code == 422
     body = response.json()
-
     assert "detail" in body
     assert "Unsupported query parameter" in body["detail"]["message"]
 
 
-def test_sort_restaurants_asc_returns_200():
-    # Router should accept sort_by and sort_order as valid query params
+def test_sort_restaurants_asc_returns_200(mocker):
+    mocker.patch.object(search_router.service.repo, "load_all_rows", return_value=FAKE_ROWS)
     response = client.get("/search/restaurants?sort_by=restaurant_name&sort_order=asc")
+
     assert response.status_code == 200
-    body = response.json()
-    names = [r["restaurant_name"] for r in body["data"]]
-    # Burger Town comes before Sushi House since it's ascending and B comes before S
+    names = [r["restaurant_name"] for r in response.json()["data"]]
+    # Burger Town comes before Sushi House in ascending order, since B comes before S
     assert names.index("Burger Town") < names.index("Sushi House")
 
 
-def test_sort_restaurants_desc_returns_200():
+def test_sort_restaurants_desc_returns_200(mocker):
+    mocker.patch.object(search_router.service.repo, "load_all_rows", return_value=FAKE_ROWS)
     response = client.get("/search/restaurants?sort_by=restaurant_name&sort_order=desc")
+
     assert response.status_code == 200
-    body = response.json()
-    names = [r["restaurant_name"] for r in body["data"]]
-    # Sushi House comes before Burger Town when descending since S comes after B
+    names = [r["restaurant_name"] for r in response.json()["data"]]
+    # Sushi House comes before Burger Town in descending order, since S comes after B
     assert names.index("Sushi House") < names.index("Burger Town")
 
 
-def test_invalid_sort_by_returns_400():
+def test_invalid_sort_by_returns_400(mocker):
+    mocker.patch.object(search_router.service.repo, "load_all_rows", return_value=FAKE_ROWS)
     # "city" is not a valid sort key for restaurants
     response = client.get("/search/restaurants?sort_by=city")
+
     assert response.status_code == 400
 
 
 def test_invalid_sort_order_returns_422():
     # sort_order must be "asc" or "desc"
     response = client.get("/search/restaurants?sort_order=random")
+
     assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Refactored test suites for PRs #68, #75, #91, #92, #93, #94, and #96 to align with the project's standard testing patterns
- Replaced SimpleNamespace user stubs with real UserInDB objects across all affected test files, so tests reflect the actual auth dependency contract
- Replaced custom mini FastAPI() test apps with app.main.app so tests run against the real application configuration
- Replaced direct monkeypatching (e.g. service.method = fake_fn) and with patch(...) context managers with mocker.patch() from pytest-mock for cleaner mock isolation and automatic teardown
- Extracted the RequestValidationError handler into app/exception_handlers.py to avoid duplicating error-formatting logic across test files
- Added pytest-mock==3.15.1 to requirements.txt