### PR TITLE
[Feat11-B1] Implementing the Simulated Refund on Paid Order Cancellation feature

### DIFF
--- a/backend/app/routers/orders.py
+++ b/backend/app/routers/orders.py
@@ -1,11 +1,10 @@
 # Orders router for API endpoints
 from uuid import UUID
 
-from app.dependencies import get_current_admin, get_current_owner
-from app.schemas.order import Order, OrderCreate, OrderStatus, OrderStatusUpdate, OrderUpdate
-from app.services import payment_service
 from app.dependencies import get_current_admin, get_current_owner, get_current_user
+from app.schemas.order import Order, OrderCreate, OrderStatus, OrderStatusUpdate, OrderUpdate
 from app.schemas.user import UserInDB
+from app.services import payment_service
 from app.services.notification_service import NotificationService
 from app.services.order_service import OrderService
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -111,7 +110,20 @@ def cancel_order(
     order_id: str,
     current_user: UserInDB = Depends(get_current_user),
 ) -> Order:
+    # Check order status before cancelling so we know whether to trigger a refund
+    existing_order = order_service.get_order(order_id)
+    was_paid = existing_order.order_status == OrderStatus.PAID
+
     order = order_service.cancel_order(order_id, str(current_user.id))
+
+    # If the refund fails for any reason, it still return the cancelled order
+    # so the system stays consistent, which the order is cancelled regardless
+    if was_paid:
+        try:
+            payment_service.refund_payment(existing_order.order_id)
+        except ValueError:
+            pass
+
     _notif_service.notify_order_status_changed(order)
     return order
 

--- a/backend/tests/test_order_modification.py
+++ b/backend/tests/test_order_modification.py
@@ -539,70 +539,6 @@ class TestOrderModificationEndpoints:
         self, uuid_order, order_repo, kaggle_repo, monkeypatch
     ):
         from app.routers import orders as orders_router
-        monkeypatch.setattr(orders_router, "order_service", order_service)
-
-        response = client.delete(
-            f"/orders/{sample_order.order_id}/cancel",
-            params={"customer_id": "cust-456"}  # Wrong customer
-        )
-        assert response.status_code == 403
-
-
-
-class TestCancelOrderRefundTrigger:
-
-    def test_cancelling_placed_order_does_not_trigger_refund(self, order_service, sample_order, mocker):
-        # A Placed order has no payment, so the refund_payment should not be called
-        mocker.patch("app.routers.orders.order_service", order_service)
-        mock_payment = mocker.patch("app.routers.orders.payment_service")
-
-        response = client.delete(
-            f"/orders/{sample_order.order_id}/cancel",
-            params={"customer_id": "cust-123"}
-        )
-        assert response.status_code == 200
-        mock_payment.refund_payment.assert_not_called()
-
-    def test_cancelling_paid_order_triggers_refund(self, order_service, sample_order, order_repo, mocker):
-        # Manually advance order to Paid status before cancelling the order
-        order_repo.update_order_status(str(sample_order.order_id), OrderStatus.PAID)
-
-        mocker.patch("app.routers.orders.order_service", order_service)
-        mock_payment = mocker.patch("app.routers.orders.payment_service")
-
-        response = client.delete(
-            f"/orders/{sample_order.order_id}/cancel",
-            params={"customer_id": "cust-123"}
-        )
-        assert response.status_code == 200
-        mock_payment.refund_payment.assert_called_once()
-
-    def test_cancelling_paid_order_refund_uses_correct_order_id(self, order_service, sample_order, order_repo, mocker):
-        # This is to make sure refund_payment is called with the correct order UUID
-        order_repo.update_order_status(str(sample_order.order_id), OrderStatus.PAID)
-
-        mocker.patch("app.routers.orders.order_service", order_service)
-        mock_payment = mocker.patch("app.routers.orders.payment_service")
-
-        client.delete(
-            f"/orders/{sample_order.order_id}/cancel",
-            params={"customer_id": "cust-123"}
-        )
-        mock_payment.refund_payment.assert_called_once_with(sample_order.order_id)
-
-    def test_cancelling_paid_order_still_returns_cancelled_status(self, order_service, sample_order, order_repo, mocker):
-        # Test that even with a refund triggered, the order should still come back as Cancelled status in the response
-        order_repo.update_order_status(str(sample_order.order_id), OrderStatus.PAID)
-
-        mocker.patch("app.routers.orders.order_service", order_service)
-        mocker.patch("app.routers.orders.payment_service")
-
-        response = client.delete(
-            f"/orders/{sample_order.order_id}/cancel",
-            params={"customer_id": "cust-123"}
-        )
-        assert response.status_code == 200
-        assert response.json()["order_status"] == "Cancelled"
 
         svc = OrderService(order_repo=order_repo, kaggle_repo=kaggle_repo)
         monkeypatch.setattr(orders_router, "order_service", svc)
@@ -610,5 +546,95 @@ class TestCancelOrderRefundTrigger:
         try:
             response = client.delete(f"/orders/{uuid_order.order_id}/cancel")
             assert response.status_code == 403
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+
+
+
+class TestCancelOrderRefundTrigger:
+
+    @pytest.fixture
+    def uuid_sample_order(self, order_repo):
+        """Order whose customer_id equals str(CUST_123_ID) so MOCK_CUST_123 passes ownership check."""
+        order_data = OrderCreate(
+            customer_id=str(CUST_123_ID),
+            restaurant_id=16,
+            food_item="Taccos",
+            order_value=25.50,
+            delivery_distance=5.0,
+            delivery_method=DeliveryMethod.BIKE,
+        )
+        return order_repo.create_order(order_data)
+
+    def test_cancelling_placed_order_does_not_trigger_refund(self, order_service, uuid_sample_order, mocker):
+        # A Placed order has no payment, so the refund_payment should not be called
+        mocker.patch("app.routers.orders.order_service", order_service)
+        mock_payment = mocker.patch("app.routers.orders.payment_service")
+
+        app.dependency_overrides[get_current_user] = lambda: MOCK_CUST_123
+        try:
+            response = client.delete(f"/orders/{uuid_sample_order.order_id}/cancel")
+            assert response.status_code == 200
+            mock_payment.refund_payment.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+
+    def test_cancelling_paid_order_triggers_refund(self, order_service, uuid_sample_order, order_repo, mocker):
+        # Manually advance order to Paid status before cancelling the order
+        order_repo.update_order_status(str(uuid_sample_order.order_id), OrderStatus.PAID)
+
+        mocker.patch("app.routers.orders.order_service", order_service)
+        mock_payment = mocker.patch("app.routers.orders.payment_service")
+
+        app.dependency_overrides[get_current_user] = lambda: MOCK_CUST_123
+        try:
+            response = client.delete(f"/orders/{uuid_sample_order.order_id}/cancel")
+            assert response.status_code == 200
+            mock_payment.refund_payment.assert_called_once()
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+
+    def test_cancelling_paid_order_refund_uses_correct_order_id(self, order_service, uuid_sample_order, order_repo, mocker):
+        # This is to make sure refund_payment is called with the correct order UUID
+        order_repo.update_order_status(str(uuid_sample_order.order_id), OrderStatus.PAID)
+
+        mocker.patch("app.routers.orders.order_service", order_service)
+        mock_payment = mocker.patch("app.routers.orders.payment_service")
+
+        app.dependency_overrides[get_current_user] = lambda: MOCK_CUST_123
+        try:
+            client.delete(f"/orders/{uuid_sample_order.order_id}/cancel")
+            mock_payment.refund_payment.assert_called_once_with(uuid_sample_order.order_id)
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+
+    def test_cancelling_paid_order_still_returns_cancelled_status(self, order_service, uuid_sample_order, order_repo, mocker):
+        # Test that even with a refund triggered, the order should still come back as Cancelled status in the response
+        order_repo.update_order_status(str(uuid_sample_order.order_id), OrderStatus.PAID)
+
+        mocker.patch("app.routers.orders.order_service", order_service)
+        mocker.patch("app.routers.orders.payment_service")
+
+        app.dependency_overrides[get_current_user] = lambda: MOCK_CUST_123
+        try:
+            response = client.delete(f"/orders/{uuid_sample_order.order_id}/cancel")
+            assert response.status_code == 200
+            assert response.json()["order_status"] == "Cancelled"
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+
+    def test_cancelling_paid_order_still_returns_200_if_refund_fails(self, order_service, uuid_sample_order, order_repo, mocker):
+        # If refund_payment raises, the cancel should still succeed, but order stays Cancelled
+        order_repo.update_order_status(str(uuid_sample_order.order_id), OrderStatus.PAID)
+
+        mocker.patch("app.routers.orders.order_service", order_service)
+        mock_payment = mocker.patch("app.routers.orders.payment_service")
+        mock_payment.refund_payment.side_effect = ValueError("Simulated refund failure")
+
+        app.dependency_overrides[get_current_user] = lambda: MOCK_CUST_123
+        try:
+            response = client.delete(f"/orders/{uuid_sample_order.order_id}/cancel")
+            assert response.status_code == 200
+            assert response.json()["order_status"] == "Cancelled"
         finally:
             app.dependency_overrides.pop(get_current_user, None)


### PR DESCRIPTION
## Summary
This PR implements Feat11-B1, which automatically triggers a simulated refund when a customer cancels an order that has already been paid. The refund logic is hooked into the existing cancel endpoint with minimal changes to keep it clean and easy to follow.

## What was implemented

- Added imports for `OrderStatus` and `payment_service` to `orders.py` so the cancel endpoint can check the order's current status and call the refund logic.

- Updated the `DELETE /orders/{order_id}/cancel` endpoint to check the order's status before cancelling. If the order was in `Paid` status, `payment_service.refund_payment()` is automatically called after the cancellation goes through. If the order was in `Placed` status, no refund is triggered since no payment was made.

- The existing cancellation behaviour is unchanged — ownership check, Kaggle order protection, and status notification all still work the same way.

- Added 4 new tests in `TestCancelOrderRefundTrigger` inside `test_order_modification.py` using `mocker` to isolate the payment service from the order cancellation logic.

## Acceptance criteria checklist

- [X]  Given a `Placed` order, when cancelled, then no refund is triggered
- [X]  Given a `Paid` order, when cancelled, then `refund_payment` is called automatically
- [X]  Given a `Paid` order cancellation, then `refund_payment` is called with the correct order UUID
- [X]  Given a `Paid` order cancellation with refund triggered, then the response still returns `Cancelled` status